### PR TITLE
Load the nibs from the correct bundle

### DIFF
--- a/RealmBrowser/Controllers/RLMBrowserEmptyViewController.m
+++ b/RealmBrowser/Controllers/RLMBrowserEmptyViewController.m
@@ -47,7 +47,7 @@
 
     self.navigationItem.titleView = [[RLMRealmLogoView alloc] initWithFrame:(CGRect){0,0,30,30}];
 
-    NSString *appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(id)kCFBundleNameKey];
+    NSString *appName = [[[NSBundle bundleForClass:self.class] infoDictionary] objectForKey:(id)kCFBundleNameKey];
     NSString *subtitleString = [NSString stringWithFormat:NSLocalizedString(@"%@ needs to open each Realm before it will appear here.", @""), appName];
     self.emptyView.subtitleLabel.text = subtitleString;
 }

--- a/RealmBrowser/Controllers/RLMBrowserObjectSchemaPickerViewController.m
+++ b/RealmBrowser/Controllers/RLMBrowserObjectSchemaPickerViewController.m
@@ -104,7 +104,8 @@ NSInteger const kRLMBrowserObjectSchemaPickerCheckTag = 101;
     [self.view addSubview:self.tableView];
     
     // Configure table cell
-    UINib *tableNib = [UINib nibWithNibName:@"RLMBrowserPropertyTableViewCell" bundle:nil];
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    UINib *tableNib = [UINib nibWithNibName:@"RLMBrowserPropertyTableViewCell" bundle:bundle];
     [self.tableView registerNib:tableNib forCellReuseIdentifier:kRLMBrowserObjectSchemaTableViewCellIdentifier];
     
     // Load Realm and the schema

--- a/RealmBrowser/Controllers/RLMBrowserObjectSchemaViewController.m
+++ b/RealmBrowser/Controllers/RLMBrowserObjectSchemaViewController.m
@@ -53,8 +53,9 @@ static NSString *kRLMBrowserObjectPropertyTableViewCellIdentifier = @"PropertyCe
 
     self.circleImage = [UIImage RLMBrowser_tintedCircleImageForRadius:15.0f];
     self.realmColors = self.realmColors = [[[UIColor RLMBrowser_realmColors] reverseObjectEnumerator] allObjects];
-
-    UINib *tableNib = [UINib nibWithNibName:@"RLMBrowserPropertyTableViewCell" bundle:nil];
+    
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    UINib *tableNib = [UINib nibWithNibName:@"RLMBrowserPropertyTableViewCell" bundle:bundle];
     [self.tableView registerNib:tableNib forCellReuseIdentifier:kRLMBrowserObjectPropertyTableViewCellIdentifier];
 
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonTapped)];

--- a/RealmBrowser/Controllers/RLMBrowserRealmListViewController.m
+++ b/RealmBrowser/Controllers/RLMBrowserRealmListViewController.m
@@ -136,12 +136,13 @@ NSString * const kRLMBrowserSchemaTableViewCellIdentifier = @"SchemaTableCell";
             [screenshot removeFromSuperview];
         }];
     }];
-
+    
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
     // Register the table cells
-    UINib *realmTableCellNib = [UINib nibWithNibName:@"RLMBrowserRealmTableViewCell" bundle:nil];
+    UINib *realmTableCellNib = [UINib nibWithNibName:@"RLMBrowserRealmTableViewCell" bundle:bundle];
     [self.tableView registerNib:realmTableCellNib forCellReuseIdentifier:kRLMBrowserRealmTableViewCellIdentifier];
 
-    UINib *schemaTableCellNib = [UINib nibWithNibName:@"RLMBrowserSchemaTableViewCell" bundle:nil];
+    UINib *schemaTableCellNib = [UINib nibWithNibName:@"RLMBrowserSchemaTableViewCell" bundle:bundle];
     [self.tableView registerNib:schemaTableCellNib forCellReuseIdentifier:kRLMBrowserSchemaTableViewCellIdentifier];
 
     self.lightColors = [[[UIColor RLMBrowser_realmColorsLight] reverseObjectEnumerator] allObjects];

--- a/RealmBrowser/Views/EmptyContentViews/RLMBrowserEmptyContentView.m
+++ b/RealmBrowser/Views/EmptyContentViews/RLMBrowserEmptyContentView.m
@@ -27,7 +27,7 @@
 
 + (instancetype)emptyView
 {
-    return [[NSBundle mainBundle] loadNibNamed:@"RLMBrowserEmptyContentView" owner:self options:nil].firstObject;
+    return [[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserEmptyContentView" owner:self options:nil].firstObject;
 }
 
 - (void)awakeFromNib

--- a/RealmBrowser/Views/FooterView/RLMBrowserSchemaPreviewView.m
+++ b/RealmBrowser/Views/FooterView/RLMBrowserSchemaPreviewView.m
@@ -26,7 +26,7 @@
 
 + (instancetype)contentView
 {
-    return [[[NSBundle mainBundle] loadNibNamed:@"RLMBrowserSchemaPreviewView" owner:self options:nil] firstObject];
+    return [[[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserSchemaPreviewView" owner:self options:nil] firstObject];
 }
 
 - (void)awakeFromNib

--- a/RealmBrowser/Views/HeaderViews/RLMBrowserNavigationTitleView.m
+++ b/RealmBrowser/Views/HeaderViews/RLMBrowserNavigationTitleView.m
@@ -26,7 +26,7 @@
 
 - (instancetype)init
 {
-    if ((self = [[NSBundle mainBundle] loadNibNamed:@"RLMBrowserNavigationTitleView"
+    if ((self = [[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserNavigationTitleView"
                                                owner:self options:nil].firstObject)) {
         
     }

--- a/RealmBrowser/Views/HeaderViews/RLMBrowserRealmHeaderView.m
+++ b/RealmBrowser/Views/HeaderViews/RLMBrowserRealmHeaderView.m
@@ -26,7 +26,7 @@
 
 + (RLMBrowserRealmHeaderView *)headerView
 {
-    return [[NSBundle mainBundle] loadNibNamed:@"RLMBrowserRealmHeaderView"
+    return [[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserRealmHeaderView"
                                          owner:self options:nil].firstObject;
 }
 

--- a/RealmBrowser/Views/TableViewCells/ObjectListTableViewCell/RLMBrowserObjectListContentView.m
+++ b/RealmBrowser/Views/TableViewCells/ObjectListTableViewCell/RLMBrowserObjectListContentView.m
@@ -26,7 +26,7 @@
 
 + (instancetype)objectListContentView
 {
-    return [[[NSBundle mainBundle] loadNibNamed:@"RLMBrowserObjectListContentView" owner:nil options:nil] firstObject];
+    return [[[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserObjectListContentView" owner:nil options:nil] firstObject];
 }
 
 - (void)configureCellWithRealmObject:(RLMObject *)object

--- a/RealmBrowser/Views/TableViewCells/ObjectTableViewCellContentView/RLMBrowserObjectContentView.m
+++ b/RealmBrowser/Views/TableViewCells/ObjectTableViewCellContentView/RLMBrowserObjectContentView.m
@@ -37,7 +37,7 @@
 
 + (instancetype)objectContentView
 {
-    RLMBrowserObjectContentView *contentView = [[[NSBundle mainBundle] loadNibNamed:@"RLMBrowserObjectContentView" owner:nil options:nil] firstObject];
+    RLMBrowserObjectContentView *contentView = [[[NSBundle bundleForClass:self.class] loadNibNamed:@"RLMBrowserObjectContentView" owner:nil options:nil] firstObject];
     contentView.propertyStatsLabel.hidden = YES;
     contentView.propertyStats = nil;
     return contentView;


### PR DESCRIPTION
When you use the library through Cocoapods, it will throw an error that the nibs can't be loaded. This addresses that.